### PR TITLE
Fix the version because the dependency of pytorch3d cannot be resolved.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: MICA
 channels:
-  - pytorch3d-nightly
+  - pytorch3d
   - pytorch
   - iopath
   - fvcore
@@ -146,7 +146,7 @@ dependencies:
   - python_abi=3.8=2_cp38
   - pytorch=1.11.0=py3.8_cuda11.3_cudnn8.2.0_0
   - pytorch-mutex=1.0=cuda
-  - pytorch3d=0.6.1=py38_cu113_pyt1110
+  - pytorch3d=0.6.2=py38_cu113_pyt1110
   - pytz=2021.3=pyhd3eb1b0_0
   - pywavelets=1.1.1=py38h7b6447c_2
   - pyyaml=5.3.1=py38h7b6447c_1


### PR DESCRIPTION
Thank you for publishing such a wonderful repository.

I found and fixed the following issues.

- "conda env create" fails because pytorch3d dependencies cannot be resolved.
    - The environment.yml refers to the pytorch3d-nightly channel, but there is no version 0.6.1 (only 0.7.0), so the dependency cannot be resolved.
    - There is a 0.6.1 version on the pytorch3d channel, but nothing that satisfies the condition "pytorch3d=0.6.1=py38_cu113_pyt1110".
    - I used "pytorch3d=0.6.2=py38_cu113_pyt1110" instead.